### PR TITLE
Fix: Address potential memory leaks in WebView Activities

### DIFF
--- a/app/src/main/java/com/example/dark/Surfer/MainActivity.java
+++ b/app/src/main/java/com/example/dark/Surfer/MainActivity.java
@@ -23,7 +23,7 @@ import android.widget.Toast;
 
 
 public class MainActivity extends AppCompatActivity implements SwipeRefreshLayout.OnRefreshListener {
-    static WebView wv;
+    WebView wv;
     SwipeRefreshLayout swipe;
     String url;
 
@@ -138,6 +138,23 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
             startActivity(i);
         }
         return false;
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (wv != null) {
+            wv.loadUrl("about:blank"); // Clear the content
+            wv.onPause();
+            wv.removeAllViews();
+            wv.destroyDrawingCache();
+            // For older Android versions, you might need to remove it from its parent first
+            // if (wv.getParent() != null) {
+            //     ((android.view.ViewGroup) wv.getParent()).removeView(wv);
+            // }
+            wv.destroy();
+            wv = null; // Nullify the reference
+        }
+        super.onDestroy();
     }
 
     @Override


### PR DESCRIPTION
This commit resolves several potential memory leaks primarily related to static references and improper resource cleanup in `WebViewActivity` and `MainActivity`.

Key changes:

1.  **Removed Static WebViews:**
    *   Changed `static WebView wv` to an instance variable `WebView wv` in both `WebViewActivity.java` and `MainActivity.java`. Static WebViews can hold onto the Activity's context, preventing garbage collection.

2.  **Removed Static UI Elements:**
    *   Changed `static EditText urlAdd, key` to instance variables in `WebViewActivity.java`.

3.  **Implemented `onDestroy` for WebViews:**
    *   Added `onDestroy()` methods to both `WebViewActivity.java` and `MainActivity.java`.
    *   These methods now include logic to properly destroy the WebView (e.g., `wv.loadUrl("about:blank")`, `wv.onPause()`, `wv.removeAllViews()`, `wv.destroyDrawingCache()`, `wv.destroy()`, and nullifying the reference). This is crucial for releasing WebView-related resources.

4.  **Corrected SQLiteDatabase Lifecycle:**
    *   In `WebViewActivity.java`, the `SQLiteDatabase db` is now an instance variable.
    *   It's initialized in `onCreate()` and properly closed in `onDestroy()` to prevent resource leaks.

5.  **Addressed Handler Leak:**
    *   In `WebViewActivity.java`, the `Handler` and `Runnable` used for the "press back again to exit" feature are now instance variables.
    *   Pending callbacks on this `Runnable` are removed in `onDestroy()` to prevent the `Runnable` (and thus the Activity) from being retained unnecessarily.

These changes should significantly improve memory management and reduce the likelihood of `OutOfMemoryError` crashes in the application. Manual testing with a memory profiler is recommended to confirm the resolution of these leaks.